### PR TITLE
Using grunt.util for newer grunt versions

### DIFF
--- a/tasks/saucelabs.js
+++ b/tasks/saucelabs.js
@@ -1,4 +1,5 @@
 module.exports = function(grunt) {
+	var _ = (grunt.utils || grunt.util)._;
 	var sauce = require('saucelabs');
 	var request = require('request');
 	var proc = require('child_process');
@@ -328,7 +329,7 @@ module.exports = function(grunt) {
 	function defaults(data) {
 		var result = {}, build = Math.floor((new Date).getTime() / 1000 - 1230768000).toString();
 		result.url = data.url || data.urls;
-		if(grunt.utils._.isArray(result.url)) {
+		if(_.isArray(result.url)) {
 			result.pages = result.url;
 		} else {
 			result.pages = [result.url];
@@ -341,7 +342,7 @@ module.exports = function(grunt) {
 		result.testInterval = data.testInterval || (1000 * 5);
 		result.onTestComplete = data.onTestComplete;
 
-		grunt.utils._.map(data.browsers, function(d) {
+		_.map(data.browsers, function(d) {
 			d.name = d.name || data.testname || "";
 			d.tags = d.tags || data.tags || [];
 			d.build = data.build || build;


### PR DESCRIPTION
`grunt.utils` was deprecated in favor of `grunt.util` in Grunt 0.4.0. See https://github.com/gruntjs/grunt/wiki/Upgrading-from-0.3-to-0.4 (last point under headline API).

With this change I was able to execute BonsaiJS tests against Saucelabs using Grunt 0.4.0.
