### PR TITLE
Fixes reference to grunt util

### DIFF
--- a/tasks/saucelabs.js
+++ b/tasks/saucelabs.js
@@ -221,7 +221,7 @@ module.exports = function(grunt) {
 				}
 
 				var brwrs = [], curr = 0, running = 0, res = true;
-				grunt.utils._.each(configs, function(_c) {
+				_.each(configs, function(_c) {
 					brwrs.push(initBrowser(_c));
 				});
 


### PR DESCRIPTION
The _ variable is a reference to either grunt.util or grunt.utils (presumably for different versions), but there is one location where `grunt.utils._` is used instead of `_`, causing an exception to be thrown on Grunt 0.4.0rc6. This fixes that exception.
