### PR TITLE
Hanging whilst waiting for "You may start your tests"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-saucelabs-qunit": "bin/grunt-saucelabs-qunit"
   },
   "engines": {
-    "node": ">=0.6"
+    "node": ">=0.8"
   },
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
On some setups Sauce-Connect.jar may not necessarily output "You may start your tests" when a tunnel is established, and will indefinitely hang.

The recommended way of detecting whether it's ready is to use the readyfile argument (for example, see the [standard shell-script method](https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh)).

Should we switch out the string matching method for detecting the readyfile (such as `fs.watch` or a `setTimeout` + `fs.exists`)?
