### PR TITLE
Cleanup Readme links and Grunt 0.4 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A Grunt task for running qunit and jasmine tests using Sauce Labs' Cloudified Br
 
 About the tool
 --------------
-The [Grunt Qunit](https://github.com/gruntjs/grunt/blob/master/docs/task_qunit.md) task runs qunit based test suites on [PhantomJS].
+The [grunt-contrib-qunit](https://github.com/gruntjs/grunt-contrib-qunit) task runs qunit based test suites on [PhantomJS](http://phantomjs.org/).
 The `saucelabs-qunit` task is very similar but runs the test suites on the cloudified browser environment provided by Sauce Labs. This ensures that subject of the test runs across different browser environment.
-The task also uses [Sauce Connect](https://saucelabs.com/docs/sauce-connect) to establish a tunnel between Sauce Labs browsers and the machine running Grunt to load local pages. This is typically useful for testing pages on localhost that are not publically accessible on the internet.
+The task also uses [Sauce Connect](https://saucelabs.com/docs/connect) to establish a tunnel between Sauce Labs browsers and the machine running Grunt to load local pages. This is typically useful for testing pages on localhost that are not publically accessible on the internet.
 The `saucelabs-jasmine` runs jasmine tests in the Sauce Labs browser. The `saucelabs-jasmine` task requires `jasmine-1.3.0`.
 
 Usage
@@ -76,19 +76,19 @@ The parameters are
 * __tunneled__: Defaults to true; Won't launch a Sauce Connect tunnel if set to false. _Optional_
 * __testname__: The name of this test, displayed on the Sauce Labs dashboard. _Optional_
 * __tags__: An array of tags displayed for this test on the Sauce Labs dashboard. This can be the build number, commit number, etc, that can be obtained from grunt. _Optional_
-* __browsers__: An array of objects representing the [various browsers](https://saucelabs.com/docs/browsers) on which this test should run.  _Optional_
+* __browsers__: An array of objects representing the [various browsers](https://saucelabs.com/docs/platforms) on which this test should run.  _Optional_
 * __tunnelTimeout__: A numeric value indicating the time to wait before closing all tunnels (default: 120). _Optional_
 * __testTimeout__ : Number of milliseconds to wait for qunit tests on each page before timeout and failing the test (default: 300000). _Optional_
 * __testInterval__ : Number of milliseconds between each retry to see if a test is completed or not (default: 5000). _Optional_
 * __testReadyTimeout__: Number of milliseconds to wait until the test-page is ready to be read (default: 5000). _Optional_
 * __onTestComplete__ : A callback that is called everytime a qunit test for a page is complete. Runs per page, per browser configuration. A true or false return value passes or fails the test, undefined return value does not alter the result of the test. For async results, call `this.async()` in the function. The return of `this.async()` is a function that should be called once the async action is completed. _Optional_
 
-A typical `test` task running from Grunt could look like `grunt.registerTask('test', 'server qunit saucelabs-qunit');` This starts a server and then runs the Qunit tests first on PhantomJS and then using the Sauce Labs browsers.
+A typical `test` task running from Grunt could look like `grunt.registerTask('test', ['server', 'qunit', 'saucelabs-qunit']);` This starts a server and then runs the Qunit tests first on PhantomJS and then using the Sauce Labs browsers.
 
 Here is an __example__ `grunt.js` file - [https://gist.github.com/4061787](https://gist.github.com/4061787).
 
 Integration with a CI system
 --------------------------
-Grunt tasks are usually run alongside a continuous integration system. For example, when using [Travis](travis-ci.org), adding the following lines in the package.json ensures that the task is installed with `npm install` is run. Registering Sauce Labs in test task using `grunt.registerTask('test', 'server saucelabs-qunit');` ensures that the CI environment runs the tests using `npm test`.
+Grunt tasks are usually run alongside a continuous integration system. For example, when using [Travis](https://travis-ci.org), adding the following lines in the package.json ensures that the task is installed with `npm install` is run. Registering Sauce Labs in test task using `grunt.registerTask('test', ['server', 'saucelabs-qunit']);` ensures that the CI environment runs the tests using `npm test`.
 To secure the Sauce Key, the CI environment can be configured to provide the key as an environment variable instead of specifying it file. CI Environments like Travis provide [ways](http://about.travis-ci.org/docs/user/build-configuration/#Secure-environment-variables) to add secure variables in the initial configuration.
-The [IndexedDBShim](http://github.com/axemclion/IndexedDBShim) is a project that uses this plugin in a CI environment. Look at the [.travis.yml](https://github.com/axemclion/IndexedDBShim/blob/master/.travis.yml) and the [grunt.js](https://github.com/axemclion/IndexedDBShim/blob/master/grunt.js) for usage example.
+The [IndexedDBShim](http://github.com/axemclion/IndexedDBShim) is a project that uses this plugin in a CI environment. Look at the [.travis.yml](https://github.com/axemclion/IndexedDBShim/blob/master/.travis.yml) and the [grunt.js](https://github.com/axemclion/IndexedDBShim/blob/master/Gruntfile.js) for usage example.


### PR DESCRIPTION
- Fixed redirected Sauce Docs
- Changed to `grunt-contrib-qunit` repo since it replaced the old qunit task
- Updated registerTask samples to use Array syntax

---

The section "Here is an **example** `grunt.js` file - [https://gist.github.com/4061787](https://gist.github.com/4061787)." still needs to be changed, but the a 0.4 gist will need to be created.
