### PR TITLE
Fixed issue with initialize browser session without tunnel

### DIFF
--- a/tasks/saucelabs.js
+++ b/tasks/saucelabs.js
@@ -501,7 +501,7 @@ module.exports = function(grunt) {
         'name': result.testname,
         'tags': result.tags,
         'build': result.build,
-        'tunnel-identifier': result.identifier
+        'tunnel-identifier': 'tunnel-identifier': result.tunneled ? result.identifier : ''
       });
     });
     result.concurrency = result.concurrency || result.browsers.length;


### PR DESCRIPTION
Hi,

I have find out that disabling param "tunneled" is cause of error:

```
Running "saucelabs-qunit:all" (saucelabs-qunit) task
=> Connecting to Saucelabs ...
>> Connected to Saucelabs
>> [XP::chrome] Could not initialize browser for session undefined { browserName: 'chrome',
>>   platform: 'XP',
>>   name: '',
>>   tags: [],
>>   build: undefined,
>>   'tunnel-identifier': '137586208',
>>   prefix: '\u001b[33mXP::chrome\u001b[39m' }
>> All tests completed with status false
Warning: Task "saucelabs-qunit:all" failed. Use --force to continue.
```

This error is related to the param "tunnel-identifier". It's set regardless of value of param "tunneled", see code below:

``` javascript
_.map(result.browsers, function(d) {
      return _.extend(d, {
        'name': result.testname,
        'tags': result.tags,
        'build': result.build,
        'tunnel-identifier': result.identifier
      });
    });
```
