### PR TITLE
Fix bug where we continue parsing version number after complaining it's not present, and crash

### DIFF
--- a/tasks/saucelabs.js
+++ b/tasks/saucelabs.js
@@ -298,6 +298,7 @@ module.exports = function(grunt) {
             grunt.log.error("[%s] More details about error at http://saucelabs.com/tests/%s", cfg.prefix, driver.sessionID);
 
             callback(false);
+            return;
           }
 
           var versionMatch = versionText.match(/[0-9]+(\.[0-9]+)*/);


### PR DESCRIPTION
If the version number could not be found (which is a problem I'm currently seeing for some reason, but unrelated), grunt-saucelabs currently records the error and clearly explains it, registers the test as failed, and then goes on and tries to parse it.

This immediately fails (with `Fatal error: Cannot call method 'match' of undefined`), which crashes grunt, so the test is not recorded as failed on saucelabs (it times out 90 seconds later), and if you're running multiple browsers in parallel you can't even tell which failed.

This now fixes that, by failing the one test and then stopping that test entirely: a quick test shows test failures now being sensibly recorded by both grunt and saucelabs itself.
