### PR TITLE
Fix bug where we continue parsing version number after complaining it's not present, and crash (to incoming-pr)

### DIFF
--- a/tasks/saucelabs.js
+++ b/tasks/saucelabs.js
@@ -298,6 +298,7 @@ module.exports = function(grunt) {
             grunt.log.error("[%s] More details about error at http://saucelabs.com/tests/%s", cfg.prefix, driver.sessionID);
 
             callback(false);
+            return;
           }
 
           var versionMatch = versionText.match(/[0-9]+(\.[0-9]+)*/);


### PR DESCRIPTION
This is #47, but rebased onto the incoming-pr branch
