### PR TITLE
Delete npmignore to default the exclusions to the gitignore version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-/node_modules/


### PR DESCRIPTION
The sauce_connect.log files were bleeding into the NPM package (along with a few other files). NPM falls back to the `.gitignore` if the `.npmignore` isn't present https://npmjs.org/doc/developers.html#Keeping-files-out-of-your-package
