### PR TITLE
Rename bin to grunt-saucelabs

### DIFF
--- a/bin/grunt-saucelabs
+++ b/bin/grunt-saucelabs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('grunt').npmTasks('grunt-saucelabs').cli();

--- a/bin/grunt-saucelabs-qunit
+++ b/bin/grunt-saucelabs-qunit
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('grunt').npmTasks('grunt-saucelabs-qunit').cli();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "grunt.js",
   "bin": {
-    "grunt-saucelabs-qunit": "bin/grunt-saucelabs-qunit"
+    "grunt-saucelabs": "bin/grunt-saucelabs"
   },
   "engines": {
     "node": ">=0.6",


### PR DESCRIPTION
Thought it made sense since the library isn't QUnit specific anymore. Might require a version bump for SemVer
