### PR TITLE
Update suggestion for QUnit integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Add the following to your QUnit test specification
 ```javascript
 var log = [];
 var testName;
-QUnit.done = function (test_results) {
+QUnit.done(function (test_results) {
   var tests = log.map(function(details){
     return {
       name: details.name,
@@ -136,7 +136,7 @@ QUnit.done = function (test_results) {
   // delaying results a bit cause in real-world
   // scenario you won't get them immediately
   setTimeout(function () { window.global_test_results = test_results; }, 2000);
-};
+});
 QUnit.testStart(function(testDetails){
   QUnit.log = function(details){
     if (!details.result) {


### PR DESCRIPTION
The current suggested code-to-add breaks integration with other frameworks like PhantomJS that also want to listen to QUnit's Done event.  QUnit.done already points to a method that adds it's argument as a listener to the Done event, which seems to be the intent here.  Proposed change is to use that method rather than replacing it.
