### PR TITLE
Fix #133 - "testname" option is broken

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -154,7 +154,7 @@ TestRunner.prototype.startJob = function (browser, url) {
       url: url,
       framework: this.framework,
       build: this.build,
-      name: this.testname
+      name: this.testName
     }
   };
   _.merge(requestParams.json, this.sauceConfig);


### PR DESCRIPTION
There was a camelcase typo, it seems.
