### PR TITLE
Fix for #141

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -126,7 +126,7 @@ TestRunner.prototype.runTest = function (browser, url) {
         .then(function (result) {
           me.reportProgress({
             type: 'jobCompleted',
-            url: url,
+            url: result.url,
             platform: result.platform,
             passed: result.passed,
             tunnelId: me.tunnelId


### PR DESCRIPTION
Fix for #141
Logging the Sauce Labs job URLs instead of the test runners' URLs.
