### PR TITLE
update sauce-tunnel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "request": "~2.35.0",
     "q": "~1.0.0",
     "saucelabs": "~0.1.1",
-    "sauce-tunnel": "~2.0.6",
+    "sauce-tunnel": "~2.1.0",
     "colors": "~0.6.2",
     "lodash": "~2.4.1"
   },


### PR DESCRIPTION
sauce-tunnel got bumped recently to 2.1.0 after it got updated to sauce-connect 4.3
