### PR TITLE
Adding testPageUrl property to result always for onTestComplete

### DIFF
--- a/src/Job.js
+++ b/src/Job.js
@@ -109,6 +109,7 @@ Job.prototype.getResult = function () {
   return this
     .complete()
     .then(function (result) {
+      result.testPageUrl = me.url;
       if (result.status === 'test error') {
         // A detailed error message should be composed here after the Sauce Labs API is
         // modified to report errors better, see #102.


### PR DESCRIPTION
Currently, when there is an error in a test (e.g. exceeded max time, or issue with a vm while running test), the onTestComplete handler gets called but the details param look like this:

``` javascript
{"url":"https://assets.saucelabs.com/jobs/a235838588d94187b90db1c9f840c9aa","platform":["Linux","Android","4.4"],"result":"Test exceeded maximum duration after 180 seconds","id":"30ec15bb03dc491caa6c3a5d4a10a8c6","job_id":"a235838588d94187b90db1c9f840c9aa","passed":true}
```

Notice how there is no way to know what test url it refers to (e.g `http://127.0.0.1:9999/bin/tests/Itemsmanager/test.html?fastanimations=true&autostart=true` ) 

This change ensures that in the error/success case, we always get a testPageUrl property. E.g.

``` javascript
{"url":"https://assets.saucelabs.com/jobs/d4d9e89a773a49838de10c9700cce439","platform":["Linux","Android","4.4"],"result":"Test exceeded maximum duration after 180 seconds","id":"866625a4a62e42b08e98431ff0adf4b3","job_id":"d4d9e89a773a49838de10c9700cce439","testPageUrl":"http://127.0.0.1:9999/bin/tests/Itemsmanager/test.html?fastanimations=true&autostart=true","passed":true}
```

The reason we need this information is that in http://try.buildwinjs.com/?r=Automated%202014-08-14%2001:37:57%20UTC#status we report the test results, and we have several empty boxes, because we are not able to correlate back to the test component since we don't get the test page url onTestComplete in the error case. 

We are temporarily consuming a fork of grunt-saucelabs that includes this change, so hopefully, this will be accepted, and we can switch back to the official npm package.

PS: thanks to @rigdern for debugging the grunt saucelabs task and suggesting the location to insert this line of code.
