### PR TITLE
Better error message for ECONNRESET

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,10 @@ function makeRequest(params) {
         return body;
       },
       function (error) {
-        throw 'Could not connect to Sauce Labs API: ' + error.toString();
+        throw [
+          'Could not connect to Sauce Labs API: ' + error.toString(),
+          params.method + ' ' + params.url
+        ].join('\n');
       }
     );
 }


### PR DESCRIPTION
I keep getting the "Could not connect to Sauce Labs API: Error: read ECONNRESET" error at various points during tests, so I'm adding this to try and help myself (and the Saucelabs Support team) track down what's going on.
