### PR TITLE
Only check job completion a maximum number of times.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Full list of parameters which can be added to a saucelabs-* task:
 * __tunnelArgs__: Array of optional arguments to be passed to the Sauce Connect tunnel. example: `['--debug', '--direct-domains', 'google.com']`. See [here](https://saucelabs.com/docs/connect) for further documentation.
 * __sauceConfig__: Map of extra parameters to be passed to sauce labs. example: `{'video-upload-on-pass': false, 'idle-timeout': 60}`. See [here](https://saucelabs.com/docs/additional-config) for further documentation.
 * __pollInterval__: Number of milliseconds between each retry to see if a test is completed or not (default: 2000). _Optional_
+* __statusCheckAttempts__: Number of times to attempt to see if a test is completed or not (default: 90).  Effectively, your tests have `statusCheckAttempts * pollInterval` seconds to complete (Thus, 180s by default).  Set to `-1` to try forever.
 * __throttled__: Maximum number of unit test pages which will be sent to Sauce Labs concurrently.  Exceeding your Sauce Labs' allowed concurrency can lead to test failures if you have a lot of unit test pages. _Optional_
 * __max-duration__: Maximum duration of a test, this is actually a Selenium Capability. Sauce Labs defaults to 180 seconds for js unit tests. _Optional_
 * __browsers__: An array of objects representing the [various browsers](https://saucelabs.com/docs/platforms) on which this test should run. _Optional_

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -23,6 +23,7 @@ module.exports = function (grunt) {
     this.user = properties.username;
     this.key = properties.key;
     this.pollInterval = properties.pollInterval;
+    this.statusCheckAttempts = properties.statusCheckAttempts;
     this.framework = framework;
     this.tunneled = properties.tunneled;
     this.tunnelId = properties.identifier;

--- a/tasks/saucelabs.js
+++ b/tasks/saucelabs.js
@@ -165,6 +165,7 @@ module.exports = function (grunt) {
     tunneled: true,
     identifier: Math.floor((new Date()).getTime() / 1000 - 1230768000).toString(),
     pollInterval: 1000 * 2,
+    statusCheckAttempts: 90,
     testname: '',
     browsers: [{}],
     tunnelArgs: [],


### PR DESCRIPTION
Sometimes jobs fail to start, or hang.  In these cases, the REST API may
never return 'complete', causing grunt-saucelabs to block 5eva.  This PR
adds a maximum limit to the number of checks made against the Sauce Labs
REST API, avoiding this.

Added a config setting, `statusCheckAttempts`, which is an integer
value.

`Job.js` will check whether the REST API returns `complete` a maximum of
`statusCheckAttempts` before throwing an error, reporting:

```
After trying #{statusCheckAttempts} times with a delay of
\\#{pollInterval}s, this job never reached 'complete' status.
```

This means that the job can run for a maximum of `statusCheckAttempts *
pollInterval`.

By default, `statusCheckAttempts` is equal to 90, giving jobs a maximum
runtime of 180 seconds, the current default max runtime after which
Sauce Labs will terminate jobs.