### PR TITLE
Add 'public' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Full list of parameters which can be added to a saucelabs-* task:
 * __browsers__: An array of objects representing the [various browsers](https://saucelabs.com/docs/platforms) on which this test should run. _Optional_
 * __onTestComplete__: A callback that is called every time a unit test for a page is complete. Runs per page, per browser configuration. Receives two arguments `(result, callback)`. `result` is the javascript object exposed to sauce labs as the results of the test. `callback` must be called, node-style (having arguments `err`, `result` where result is a true/false boolean which sets the test result reported to the command line). See [example below](#ontestcomplete-callback) _Optional_
 * __maxRetries__: Specifies how many times the timed out tests should be retried (default: 0). _Optional_
+* __public__: The [job visibility level](https://docs.saucelabs.com/reference/test-configuration/#job-visibility). Defaults to 'team'. _Optional_
 
 A typical `test` task running from Grunt could look like `grunt.registerTask('test', ['server', 'qunit', 'saucelabs-qunit']);` This starts a server and then runs the QUnit tests first on PhantomJS and then using the Sauce Labs browsers.
 

--- a/src/Job.js
+++ b/src/Job.js
@@ -46,6 +46,7 @@ module.exports = function (grunt) {
     this.url = url;
     this.platform = _.isArray(browser) ? browser : [browser.platform || '', browser.browserName || '', browser.version || ''];
     this.build = runner.build;
+    this.public = browser.public || runner.public || "team";
     this.tags = browser.tags || runner.tags;
     this.testName = browser.name || runner.testName;
     this.sauceConfig = runner.sauceConfig;
@@ -70,6 +71,7 @@ module.exports = function (grunt) {
         url: this.url,
         framework: this.framework,
         build: this.build,
+        public: this.public,
         tags: this.tags,
         name: this.testName
       }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
     this.tunnelId = properties.identifier;
     this.testName = properties.testname;
     this.build = properties.build;
+    this.public = properties.public;
     this.tags = properties.tags;
     this.sauceConfig = properties.sauceConfig;
     this.onTestComplete = properties.onTestComplete;


### PR DESCRIPTION
This change allows the 'public' parameter to be passed in, which defines the job visibility level. It works at both a job level and a task level. More details here:

https://docs.saucelabs.com/reference/test-configuration/#job-visibility

Closes #77 