### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,26 +29,26 @@
     "test": "grunt"
   },
   "dependencies": {
-    "colors": "~1.0.0",
-    "lodash": "~3.7.0",
-    "q": "~1.3.0",
-    "requestretry": "~1.2.2",
+    "colors": "~1.1.2",
+    "lodash": "~3.10.1",
+    "q": "~1.4.1",
+    "requestretry": "~1.6.0",
     "sauce-tunnel": "~2.3.0",
-    "saucelabs": "~0.1.1"
+    "saucelabs": "~1.0.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-contrib-connect": "^0.9.0",
+    "grunt-contrib-connect": "^0.11.2",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jscs": "^1.0.0",
+    "grunt-jscs": "^2.6.0",
     "grunt-sauce-tunnel": "^0.2.1",
-    "load-grunt-config": "^0.16.0",
+    "load-grunt-config": "^0.19.1",
     "merge": "^1.1.3",
-    "publish": "^0.3.2"
+    "publish": "^0.5.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Currently most of the dependencies used by grunt-saucelabs are outdated.

In particular the saucelabs package used by grunt-saucelabs is oone of the first unsable releases (0.1.1)

![screenshot from 2016-01-08 15 10 34](https://cloud.githubusercontent.com/assets/217034/12199808/3ed0a2fe-b61b-11e5-86b9-50b46f01ec9f.png)

This pull request takes care to update all dependencies to the latest version.

