### PR TITLE
Improve configuration of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: node_js
+sudo: false
 
 node_js:
-  - "0.10"
+  - "0.12"
+  - "4.2"
+
+cache:
+  directories:
+    - node_modules
 
 env:
   global:


### PR DESCRIPTION
With this commit:

- tests are runned both against node 0.12 and 4.2 (the LTS version); 0.10 can now be considered a ghost from the past;
- tests are moved to the new travisci infrastructure (sudo: false)
- npm packages are cached in order to both speed up the buolds and not impact on travisCI with unndeded networking