### PR TITLE
Ensure key option isn't printed to console

### DIFF
--- a/src/Job.js
+++ b/src/Job.js
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
     var requestParams = {
       method: 'POST',
       url: ['https://saucelabs.com/rest/v1', this.user, 'js-tests'].join('/'),
-      auth: { user: this.user, pass: this.key },
+      auth: { user: this.user, pass: this.key() },
       json: {
         platforms: [this.platform],
         url: this.url,
@@ -141,7 +141,7 @@ module.exports = function (grunt) {
         .makeRequest({
           method: 'POST',
           url: ['https://saucelabs.com/rest/v1', me.user, 'js-tests/status'].join('/'),
-          auth: { user: me.user, pass: me.key },
+          auth: { user: me.user, pass: me.key() },
           json: { 'js tests': [me.taskId] }
         })
         .then(function (body) {
@@ -182,7 +182,7 @@ module.exports = function (grunt) {
     return utils.makeRequest({
       method: 'PUT',
       url: ['https://saucelabs.com/rest/v1', this.user, 'jobs', this.id, 'stop'].join('/'),
-      auth: { user: this.user, pass: this.key }
+      auth: { user: this.user, pass: this.key() }
     });
   };
 
@@ -196,7 +196,7 @@ module.exports = function (grunt) {
     return utils.makeRequest({
       method: 'DELETE',
       url: ['https://saucelabs.com/rest/v1', this.user, 'jobs', this.id].join('/'),
-      auth: { user: this.user, pass: this.key }
+      auth: { user: this.user, pass: this.key() }
     });
   };
 


### PR DESCRIPTION
He folks! This patch addresses issue #203.

The options hash will now be printed like this when Grunt is running in verbose mode:

```
Options: ...snip..., key="[hidden]", ...snip...
```

Try it on your own! Just run: `grunt --verbose`

I freely admit that this code might be a bit confusing because of the mismatched API. By "mismatched", I mean that you assign a value like you normally would:

```javascript
options.key = "My secret key";
```

But to read the value, you need to call a function:

```javascript
{ key: options.key() }
```

There are a few reasons I went this route:

1. [grunt.log.writeflags](https://github.com/gruntjs/grunt-legacy-log/blob/master/index.js#L263), which is used to print the hash of options when in verbose mode, uses `JSON.stringify`, so I needed to override the toJSON function. This meant I had to return an object.
2. This integrates nicely with the [this.options](https://github.com/gruntjs/grunt/blob/00fa3badfc7cdf87fc65d90b8f4442026ec639f9/lib/util/task.js#L336) Grunt function, which uses assignment
3. It meant I didn't have to rewire how this gets passed through the entire API
4. The 'key' property can still be set as an option, and this will still work
5. The key will still show up when enumerated, so it's easy to see that a value was set, even if you can't see what it was