### PR TITLE
Allow to configure custom onProgress

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -174,6 +174,7 @@ module.exports = function (grunt) {
           jobUrl: result.url,
           platform: result.platform,
           passed: result.passed,
+          result: result.result,
           tunnelId: me.tunnelId
         });
 

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
     this.browsers = properties.browsers;
     this.urls = properties.url || properties.urls;
     this.maxRetries = properties.maxRetries;
-    this.onProgress = onProgress;
+    this.onProgress = properties.onProgress || onProgress;
 
     if (properties['max-duration']) {
       // max-duration is actually a sauce selenium capability


### PR DESCRIPTION
*see #194*

This project is really, really helpful. The only thing I would like to change is the comand line output. However, I realize that you may need different output based on context. So I propose two tiny changes that would allow users to create custom progress reporters.

The first change is to allow to configure `TestRunner.onProgress()`. The second is to pass `result` in the jobComplete report. This makes it possible to output more details about the tests.

Example: [This travis build](https://travis-ci.org/xi/muu/builds/74429477) used [this Gruntfile](https://github.com/xi/muu/blob/master/Gruntfile.js).