### PR TITLE
add check for test that errors before even starting a job

### DIFF
--- a/src/Job.js
+++ b/src/Job.js
@@ -148,6 +148,10 @@ module.exports = function (grunt) {
           var result = body['js tests'] && body['js tests'][0];
           var jobId = result.job_id;
 
+          if (result.status === 'test error') {
+            throw new Error("test throws unknown error");
+          }
+
           if (!body.completed || !reJobId.test(jobId)) {
             var retries = attempts - 1;
             if (attempts === 0) {


### PR DESCRIPTION
fixes https://github.com/axemclion/grunt-saucelabs/issues/177

when saucelabs cant start a job for a test it will error with:
```
{ completed: false,
  'js tests': 
   [ { status: 'test error',
       platform: [Object],
       id: '7c738f49617046b79f6d3660c0668053',
       job_id: 'job not ready' } ] }
```

this should be caught because atm it's causing an infinite loop until canceled (with attempts is set to -1).

this likely occurs when you're trying to specific a platform / version that saucelabs doesn't have, for example I ran into this with:
```
{
        browserName: 'firefox',
        platform: 'Linux',
        version: '47'
}
```


unfortunately I can't really figure out how your tests are being ran, so can;'t add a test for this :(