### PR TITLE
Handle 'test error' to deal with error response from invalid browsers.

### DIFF
--- a/src/Job.js
+++ b/src/Job.js
@@ -148,6 +148,10 @@ module.exports = function (grunt) {
           var result = body['js tests'] && body['js tests'][0];
           var jobId = result.job_id;
 
+          if(result.status === "test error"){
+            throw new Error(result.status);
+          }
+
           if (!body.completed || !reJobId.test(jobId)) {
             var retries = attempts - 1;
             if (attempts === 0) {


### PR DESCRIPTION
Tested with configuration:

```
      'saucelabs-custom': {
        all: {
          options: {
            urls: [
              'http://127.0.0.1:3000/'
            ],
            browsers: [
              {
                browserName : 'chrome',
                platform : 'OS X 10.11',
                version : 26 
              }
            ],
            statusCheckAttempts : -1
          }
        }
      }
```

Chrome 26 on OS X 10.11 is unsupported by sauce labs. Returns a response where `result.status` is `"test error"`. Expected behavior: test fails with an error. Actual behavior: request will be re-attempted, and when statusCheckAttempts is set to -1, the test will never complete.

This PR causes the test to complete with an error.
